### PR TITLE
Allow specifying default route for service pulse

### DIFF
--- a/src/Particular.PlatformSample/AppLauncher.cs
+++ b/src/Particular.PlatformSample/AppLauncher.cs
@@ -55,10 +55,11 @@
             platformJob.AddProcess(proc);
         }
 
-        public void ServicePulse(int port, int serviceControlPort, int monitoringPort)
+        public void ServicePulse(int port, int serviceControlPort, int monitoringPort, string defaultRoute)
         {
             var config = GetResource("Particular.configs.app.constants.js");
 
+            config = config.Replace("{DefaultRoute}", defaultRoute ?? "/dashboard");
             config = config.Replace("{ServiceControlPort}", serviceControlPort.ToString());
             config = config.Replace("{MonitoringPort}", monitoringPort.ToString());
 

--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -24,7 +24,8 @@
         /// message transport.
         /// </summary>
         /// <param name="showPlatformToolConsoleOutput">By default the output of each application is suppressed. Set to true to show tool output in the console window.</param>
-        public static void Launch(bool showPlatformToolConsoleOutput = false)
+        /// <param name="servicePulseDefaultRoute">By default the ServicePulse dashboard (/dashboard) is displayed. Set the default route to any valid ServicePulse route such as (/monitored_endpoints).</param>
+        public static void Launch(bool showPlatformToolConsoleOutput = false, string servicePulseDefaultRoute = null)
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -77,7 +78,7 @@
                 launcher.Monitoring(monitoringPort, monitoringLogs, finder.SolutionRoot);
 
                 Console.WriteLine("Launching ServicePulse");
-                launcher.ServicePulse(pulsePort, controlPort, monitoringPort);
+                launcher.ServicePulse(pulsePort, controlPort, monitoringPort, servicePulseDefaultRoute);
 
                 Console.WriteLine("Waiting for ServiceControl to be available...");
                 Network.WaitForHttpOk($"http://localhost:{controlPort}/api", httpVerb: "GET", cancellationToken: tokenSource.Token);

--- a/src/Particular.PlatformSample/configs/app.constants.js
+++ b/src/Particular.PlatformSample/configs/app.constants.js
@@ -4,7 +4,7 @@
         .constant('version', '1.15.0')
         .constant('showPendingRetry', false)
         .constant('scConfig', {
-            default_route: '/dashboard',
+            default_route: '{DefaultRoute}',
             service_control_url: 'http://localhost:{ServiceControlPort}/api',
             monitoring_urls: ['http://localhost:{MonitoringPort}/']
         });


### PR DESCRIPTION
While attempting to port the MonitoringDemo to the platform package I recognized with a hint from awesome @tmasternak that we need the capability to open ServicePulse with a given predefined view depending on the use case. This enables that

See https://github.com/Particular/MonitoringDemo/blob/master/Platform/servicepulse/app/js/app.constants.js#L7