### PR TITLE
Output ServiceControl API URL

### DIFF
--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -85,6 +85,10 @@
 
                 if (!tokenSource.IsCancellationRequested)
                 {
+                    var serviceControlApiUrl = $"http://localhost:{controlPort}/api";
+                    Console.WriteLine();
+                    Console.WriteLine($"ServiceControl API can now be accessed via: {serviceControlApiUrl}");
+                    
                     var servicePulseUrl = $"http://localhost:{pulsePort}";
                     Console.WriteLine();
                     Console.WriteLine($"ServicePulse can now be accessed via: {servicePulseUrl}");


### PR DESCRIPTION
When running a demo could be interesting to show ServiceInsight as well, in which case the ServiceControl API URL is needed to point ServiceInsight to the correct ServiceControl instance.

The proposed change simply outputs to the console the full ServiceControl API URL that can be copy/pasted into ServiceInsight to quickly connect to the correct ServiceControl instance.