### PR TITLE
Enable assembly loading without file unlocking for when running from remote binaries

### DIFF
--- a/src/Particular.PlatformSample/configs/ServiceControl.Monitoring.exe.config
+++ b/src/Particular.PlatformSample/configs/ServiceControl.Monitoring.exe.config
@@ -16,5 +16,6 @@
         <bindingRedirect oldVersion="0.0.0.0-4.6.0.0" newVersion="4.6.0.0" />
       </dependentAssembly>
     </assemblyBinding>
+    <loadFromRemoteSources enabled="true"/>
   </runtime>
 </configuration>

--- a/src/Particular.PlatformSample/configs/ServiceControl.exe.config
+++ b/src/Particular.PlatformSample/configs/ServiceControl.exe.config
@@ -23,5 +23,6 @@ These settings are only here so that we can debug ServiceControl while developin
   </connectionStrings>
   <runtime>
     <gcServer enabled="true" />
+    <loadFromRemoteSources enabled="true"/>
   </runtime>
 </configuration>


### PR DESCRIPTION
## Problem
If the launcher is dowloaded as a build binaries from the internet e.g. *Monitoring Demo* a zip ball or all files need to be unlocked othersize a following error is shown 

```
Found free port '49200' for ServiceControl
Found free port '49201' for ServiceControl Maintenance
Found free port '49202' for ServiceControl Monitoring
Found free port '49203' for ServicePulse
Solution Folder: C:\tmp\Particular.MonitoringDemo
Creating log folders
Creating transport folder
Launching ServiceControl
Launching ServiceControl Monitoring
Launching ServicePulse
2019-01-11 13:52:43.5894|1|Info|ServiceBus.Management.Infrastructure.Settings.Settings|No settings found for error log queue to import, default name will be used
2019-01-11 13:52:43.6994|1|Info|ServiceBus.Management.Infrastructure.Settings.Settings|No settings found for audit log queue to import, default name will be used

Unhandled Exception: System.Exception: Configuration of transport Failed. Ensure the assembly 'C:\tmp\Particular.MonitoringDemo\Platform\net461\platform\servicecontrol\servicecontrol-instance\ServiceControl.Transports.Learning.dll' is present and that type is correctly defined in settings ---> System.NotSupportedException: An attempt was made to load an assembly from a network location which would have caused the assembly to be sandboxed in previous versions of the .NET Framework. This release of the .NET Framework does not enable CAS policy by default, so this load may be dangerous. If this load is not intended to sandbox the assembly, please enable the loadFromRemoteSources switch. See http://go.microsoft.com/fwlink/?LinkId=155569 for more information.
   at System.Reflection.RuntimeAssembly.nLoadFile(String path, Evidence evidence)
   at System.Reflection.Assembly.LoadFile(String path)
   at ServiceBus.Management.Infrastructure.Settings.Settings.GetTransportType()
   --- End of inner exception stack trace ---
   at ServiceBus.Management.Infrastructure.Settings.Settings.GetTransportType()
   at ServiceBus.Management.Infrastructure.Settings.Settings..ctor(String serviceName)
   at Particular.ServiceControl.Hosting.Host.OnStart(String[] args)
   at Particular.ServiceControl.Hosting.Host.Run(Boolean interactive)
   at Particular.ServiceControl.Commands.RunCommand.RunAndWait(HostArguments args)
   at Particular.ServiceControl.Commands.CommandRunner.Execute(HostArguments args)
   at Particular.ServiceControl.Program.Main(String[] args)
2019-01-11 13:52:43.9554|1|Info|LoggingConfiguration|Logging to C:\tmp\Particular.MonitoringDemo\.logs\monitoring\logfile.2019-01-11.txt with LogLevel 'Warn'
Waiting for ServiceControl to be available.System.Exception: Could not load 'C:\tmp\Particular.MonitoringDemo\Platform\net461\platform\servicecontrol\monitoring-instance\Nancy.Hosting.Self.dll'. Consider excluding that assembly from the scanning. ---> System.IO.FileLoadException: Could not load file or assembly 'file:///C:\tmp\Particular.MonitoringDemo\Platform\net461\platform\servicecontrol\monitoring-instance\Nancy.Hosting.Self.dll' or one of its dependencies. Operation is not supported. (Exception from HRESULT: 0x80131515) ---> System.NotSupportedException: An attempt was made to load an assembly from a network location which would have caused the assembly to be sandboxed in previous versions of the .NET Framework. This release of the .NET Framework does not enable CAS policy by default, so this load may be dangerous. If this load is not intended to sandbox the assembly, please enable the loadFromRemoteSources switch. See http://go.microsoft.com/fwlink/?LinkId=155569 for more information.
   --- End of inner exception stack trace ---
   at System.Reflection.RuntimeAssembly._nLoad(AssemblyName fileName, String codeBase, Evidence assemblySecurity, RuntimeAssembly locationHint, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.RuntimeAssembly.nLoad(AssemblyName fileName, String codeBase, Evidence assemblySecurity, RuntimeAssembly locationHint, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.RuntimeAssembly.InternalLoadAssemblyName(AssemblyName assemblyRef, Evidence assemblySecurity, RuntimeAssembly reqAssembly, StackCrawlMark& stackMark, IntPtr pPrivHostBinder, Boolean throwOnFileNotFound, Boolean forIntrospection, Boolean suppressSecurityChecks)
   at System.Reflection.RuntimeAssembly.InternalLoadFrom(String assemblyFile, Evidence securityEvidence, Byte[] hashValue, AssemblyHashAlgorithm hashAlgorithm, Boolean forIntrospection, Boolean suppressSecurityChecks, StackCrawlMark& stackMark)
   at System.Reflection.Assembly.LoadFrom(String assemblyFile)
   at NServiceBus.Hosting.Helpers.AssemblyScanner.TryLoadScannableAssembly(String assemblyPath, AssemblyScannerResults results, Assembly& assembly)
   --- End of inner exception stack trace ---
   at NServiceBus.Hosting.Helpers.AssemblyScanner.TryLoadScannableAssembly(String assemblyPath, AssemblyScannerResults results, Assembly& assembly)
   at NServiceBus.Hosting.Helpers.AssemblyScanner.GetScannableAssemblies()
   at NServiceBus.EndpointConfiguration.Scan(AssemblyScanner assemblyScanner)
   at NServiceBus.EndpointConfiguration.GetAllowedTypes(String path)
   at NServiceBus.EndpointConfiguration.Build()
   at NServiceBus.Endpoint.Create(EndpointConfiguration configuration)
   at NServiceBus.Endpoint.<Start>d__1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at ServiceControl.Monitoring.HostService.<AsyncOnStart>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at ServiceControl.Monitoring.HostService.OnStart(String[] args)
   at ServiceControl.Monitoring.HostService.Run(Boolean interactive)
   at ServiceControl.Monitoring.RunCommand.<RunAndWait>d__2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at ServiceControl.Monitoring.CommandRunner.<Run>d__2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at ServiceControl.Monitoring.Program.Main(String[] args)
.....

```

## Solution
Add <loadFromRemoteSources enabled="true"/>  to both SC services.