### PR TITLE
Updating to newest sc package versions

### DIFF
--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.1.0" PrivateAssets="none" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl.Monitoring" Version="2.3.0" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.4.0-alpha0002" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl.Monitoring" Version="4.4.0-alpha0002" PrivateAssets="none" />
     <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.21.0" PrivateAssets="none" />
   </ItemGroup>
 

--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.4.0-alpha0002" PrivateAssets="none" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl.Monitoring" Version="4.4.0-alpha0002" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.3.1" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl.Monitoring" Version="4.3.1" PrivateAssets="none" />
     <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.21.0" PrivateAssets="none" />
   </ItemGroup>
 


### PR DESCRIPTION
We are using the alpha version not to burn `4.4.0-alpha0002` ServiceControl version. 

Once ServiceControl `4.4.0` is released the versions used here can be switched to `4.4.0`