### PR TITLE
Update to SC 4.5.0

### DIFF
--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -13,8 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Particular.Packaging" Version="0.3.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.4.1" PrivateAssets="none" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl.Monitoring" Version="4.4.1" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.5.0" PrivateAssets="none" />
     <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.22.0" PrivateAssets="none" />
   </ItemGroup>
 

--- a/src/Particular.PlatformSample/configs/ServiceControl.Monitoring.exe.config
+++ b/src/Particular.PlatformSample/configs/ServiceControl.Monitoring.exe.config
@@ -4,7 +4,7 @@
     <add key="Monitoring/HttpHostname" value="localhost" />
     <add key="Monitoring/HttpPort" value="{MonitoringPort}" />
     <add key="Monitoring/LogPath" value="{LogPath}" />
-    <add key="Monitoring/TransportType" value="NServiceBus.ServiceControlLearningTransport, ServiceControl.Transports.LearningTransport" />
+    <add key="Monitoring/TransportType" value="ServiceControl.Transports.Learning.LearningTransportCustomization, ServiceControl.Transports.Learning" />
   </appSettings>
   <connectionStrings>
     <add name="NServiceBus/Transport" connectionString="{TransportPath}" />


### PR DESCRIPTION
This PR updates `Particular.PlatformSample.ServiceControl` to 4.5.0 and removes `Particular.PlatformSample.ServiceControl.Monitoring` as both SC and Monitoring instances are shipped in one package after the seams have been [merged](https://github.com/Particular/ServiceControl/pull/1833).