### PR TITLE
Fixing the audit instance configuration - using inmemory persistence

### DIFF
--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.27.7" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.28.3" PrivateAssets="none" />
     <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.33.1" PrivateAssets="none" />
   </ItemGroup>
 

--- a/src/Particular.PlatformSample/configs/ServiceControl.Audit.exe.config
+++ b/src/Particular.PlatformSample/configs/ServiceControl.Audit.exe.config
@@ -11,7 +11,7 @@ These settings are only here so that we can debug ServiceControl while developin
     <add key="ServiceControl.Audit/LogPath" value="{LogPath}" />
     <add key="ServiceControl.Audit/DBPath" value="{DbPath}" />
     <add key="ServiceControl.Audit/TransportType" value="ServiceControl.Transports.Learning.LearningTransportCustomization, ServiceControl.Transports.Learning" />
-    <add key="ServiceControl.Audit/PersistenceType" value="ServiceControl.Audit.Persistence.RavenDb.RavenDbPersistenceConfiguration, ServiceControl.Audit.Persistence.RavenDb" />
+    <add key="ServiceControl.Audit/PersistenceType" value="ServiceControl.Audit.Persistence.InMemory.InMemoryPersistenceConfiguration, ServiceControl.Audit.Persistence.InMemory" />
     <add key="ServiceControl.Audit/ForwardAuditMessages" value="false" />
     <add key="Raven/Esent/MaxVerPages" value="4096" />
     <add key="ServiceControl.Audit/AuditRetentionPeriod" value="10.00:00:00" />


### PR DESCRIPTION
Audit Instance should be using the persister that is provided in the nuget package i.e. in-memory peristence.