### PR TITLE
Bump Particular.PlatformSample.ServicePulse from 1.36.0 to 1.36.3

### DIFF
--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="all" />
     <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.30.1" PrivateAssets="none" />
-    <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.36.0" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.36.3" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Release notes: https://github.com/Particular/ServicePulse/releases/tag/1.36.3

Commits:

- [__#1507__](https://github.com/Particular/ServicePulse/issues/1507) Top navigation bar gets hidden for small viewport widths (less than 1420px)
- [__#1503__](https://github.com/Particular/ServicePulse/issues/1503) Navigation bar does not align at narrow widths