### PR TITLE
Bump Particular.PlatformSample.ServiceControl from 4.30.1 to 4.31.0

### DIFF
--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.30.1" PrivateAssets="none" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="4.31.0" PrivateAssets="none" />
     <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.36.3" PrivateAssets="none" />
   </ItemGroup>
 


### PR DESCRIPTION
Release notes: https://github.com/Particular/ServiceControl/releases/tag/4.31.0

Commits:
- https://github.com/Particular/ServiceControl/pull/3528 Improve the experience when running and debugging ServiceControl instances locally
- https://github.com/Particular/ServiceControl/pull/3552 Include the LearningTransport option in the ServiceControl Management Utility (SCMU)
- https://github.com/Particular/ServiceControl/pull/3547 Introduce an initial and minimal persistence seam for the ServiceControl primary instance