### PR TITLE
Add visual tests

### DIFF
--- a/src/Particular.PlatformSample.Tests/.editorconfig
+++ b/src/Particular.PlatformSample.Tests/.editorconfig
@@ -2,3 +2,6 @@
 
 # Justification: Tests don't support cancellation and don't need to forward IMessageHandlerContext.CancellationToken
 dotnet_diagnostic.NSB0002.severity = suggestion
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none

--- a/src/Particular.PlatformSample.Tests/Particular.PlatformSample.Tests.csproj
+++ b/src/Particular.PlatformSample.Tests/Particular.PlatformSample.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,7 @@
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit.Analyzers " Version="4.6.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="4.28.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -1,6 +1,7 @@
 namespace Particular.PlatformSample.Tests;
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +36,17 @@ public class VisualTests
 
         await Network.WaitForHttpOk($"http://localhost:{TestPortsInternal.ServicePulse}", cancellationToken: timeoutTokenSource.Token);
 
-        driver = new ChromeDriver();
+        var chromeOpts = new ChromeOptions();
+        chromeOpts.AddArgument("--headless=new");
+        if (Environment.GetEnvironmentVariable("CI") == "true")
+        {
+            var runnerTemp = Environment.GetEnvironmentVariable("RUNNER_TEMP");
+            var dataDir = Path.Combine(runnerTemp, "browser-testing");
+            Directory.CreateDirectory(dataDir);
+            chromeOpts.AddArgument($"--user-data-dir={dataDir}");
+        }
+
+        driver = new ChromeDriver(chromeOpts);
     }
 
     [OneTimeTearDown]

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -1,0 +1,54 @@
+namespace Particular.PlatformSample.Tests;
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+
+[FixtureLifeCycle(LifeCycle.SingleInstance)]
+public class VisualTests
+{
+    Task launcherTask;
+    CancellationTokenSource closePlatformTokenSource;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        closePlatformTokenSource = new CancellationTokenSource();
+
+        launcherTask = Task.Run(async () =>
+        {
+            await PlatformLauncher.Launch(cancellationToken: closePlatformTokenSource.Token);
+        });
+
+        using var timeoutTokenSource = new CancellationTokenSource(30_000);
+        await Network.WaitForHttpOk("http://localhost:49205", cancellationToken: timeoutTokenSource.Token);
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        await closePlatformTokenSource.CancelAsync();
+        await launcherTask;
+        closePlatformTokenSource.Dispose();
+    }
+
+    [Test]
+    public async Task CheckMonitoringPage()
+    {
+        var driver = new ChromeDriver();
+        driver.Navigate().GoToUrl("http://localhost:49205/#/monitoring");
+        await Task.Delay(5000);
+
+        var connectionFailedSpans = driver.FindElements(By.CssSelector(".connection-failed"));
+        Assert.That(connectionFailedSpans.Count, Is.EqualTo(0));
+
+        var primaryButtons = driver.FindElements(By.CssSelector(".btn.btn-primary"));
+        var noEndpointsButton = primaryButtons.Where(b => b.Text.Contains("how to enable endpoint monitoring")).FirstOrDefault();
+
+        Assert.That(noEndpointsButton, Is.Not.Null);
+        Assert.That(noEndpointsButton.GetAttribute("href"), Is.EqualTo("https://docs.particular.net/monitoring/metrics/"));
+    }
+}

--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -31,10 +31,14 @@
 
             var wait = new ManualResetEvent(false);
 
+            tokenSource.Token.Register(() =>
+            {
+                wait.Set();
+            });
+
             Console.CancelKeyPress += (sender, args) =>
             {
                 args.Cancel = true;
-                wait.Set();
                 tokenSource.Cancel();
             };
 

--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -51,6 +51,8 @@
             var monitoringPort = ports[4];
             var pulsePort = ports[5];
 
+            TestPortsInternal.ServicePulse = pulsePort;
+
             Console.WriteLine($"Found free port '{controlPort}' for ServiceControl");
             Console.WriteLine($"Found free port '{auditPort}' for ServiceControl Audit");
             Console.WriteLine($"Found free port '{maintenancePort}' for ServiceControl Maintenance");

--- a/src/Particular.PlatformSample/TestPortsInternal.cs
+++ b/src/Particular.PlatformSample/TestPortsInternal.cs
@@ -1,0 +1,6 @@
+namespace Particular;
+
+static class TestPortsInternal
+{
+    public static int ServicePulse { get; set; }
+}


### PR DESCRIPTION
Visually test the ServicePulse instance to see that ServiceControl & Monitoring are connected, and that the monitoring page shows the button to add endpoints.

This replaces the manual testing of the MonitoringDemo that previously occurred after ServiceControl and ServicePulse releases.

Also related to the following PRs to simplify the ServiceControl and ServicePulse release procedure:

* https://github.com/Particular/Particular.PlatformSample/pull/475
* https://github.com/Particular/MonitoringDemo/pull/195