### PR TITLE
Release straight to NuGet, without Octopus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,5 @@ jobs:
           name: nugets
           path: nugets/*
           retention-days: 1
-      - name: Deploy
-        # Does not follow standard practice of targeting explicit versions because configuration is tightly coupled to Octopus Deploy configuration
-        uses: Particular/push-octopus-package-action@main
-        with:
-          octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
+      - name: Deploy to NuGet
+        run: dotnet nuget push nugets/*.nupkg --api-key ${{ secrets.NUGET_PUBLISH_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/README.md
+++ b/README.md
@@ -80,11 +80,10 @@ When finished, commit the changes to a branch and raise a pull request against m
 As we don't care about patching older releases, the Platform Sample uses a simplified version of Release Flow that, in most cases, does not require `release-X.Y` branches.
 
 * Builds on the master branch will, by default, create an alpha version of the next minor.
-* To create a production release, tag the master branch with the full version number. GitHub Actions will build it and push it to Octopus.
+* To create a production release, tag the master branch with the full version number. GitHub Actions will build it and push it directly to NuGet.
 * All normal releases (most often updating the platform tools versions) should increment the minor.
   * A major version need only be released in the event of a breaking change in the API.
   * Patch releases generally should be avoided. If one is necessary, a release branch would need to be created from the point of the tagged minor, and the patch released from there.
-* Deploy to NuGet by promoting in Octopus.
 
 ### Why not use version ranges / wildcard dependency?
 


### PR DESCRIPTION
After merging, the Octopus project for Particular.PlatformSample can be deleted.