### PR TITLE
Release straight to NuGet, without Octopus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
+defaults:
+  run:
+    shell: pwsh
 jobs:
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,5 @@ jobs:
           name: nugets
           path: nugets/*
           retention-days: 1
-      - name: Deploy
-        # Does not follow standard practice of targeting explicit versions because configuration is tightly coupled to Octopus Deploy configuration
-        uses: Particular/push-octopus-package-action@main
-        with:
-          octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
+      - name: Deploy to NuGet
+        run: dotnet nuget push nugets/*.nupkg --api-key ${{ secrets.NUGET_PUBLISH_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,4 @@ jobs:
           path: nugets/*
           retention-days: 1
       - name: Deploy to NuGet
-        run: dotnet nuget push nugets/*.nupkg --api-key ${{ secrets.NUGET_PUBLISH_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push nugets/*.nupkg --api-key ${{ secrets.NUGET_PUBLISH_API_KEY }} --source ${{ vars.NUGET_API_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-*'
 env:
   DOTNET_NOLOGO: true
+defaults:
+  run:
+    shell: bash
 jobs:
   release:
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -80,11 +80,10 @@ When finished, commit the changes to a branch and raise a pull request against m
 As we don't care about patching older releases, the Platform Sample uses a simplified version of Release Flow that, in most cases, does not require `release-X.Y` branches.
 
 * Builds on the master branch will, by default, create an alpha version of the next minor.
-* To create a production release, tag the master branch with the full version number. GitHub Actions will build it and push it to Octopus.
+* To create a production release, tag the master branch with the full version number. GitHub Actions will build it and push it directly to NuGet.
 * All normal releases (most often updating the platform tools versions) should increment the minor.
   * A major version need only be released in the event of a breaking change in the API.
   * Patch releases generally should be avoided. If one is necessary, a release branch would need to be created from the point of the tagged minor, and the patch released from there.
-* Deploy to NuGet by promoting in Octopus.
 
 ### Why not use version ranges / wildcard dependency?
 

--- a/src/Particular.PlatformSample/Particular.PlatformSample.csproj
+++ b/src/Particular.PlatformSample/Particular.PlatformSample.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Packaging" Version="4.2.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="6.1.2" PrivateAssets="none" AutomaticVersionRange="false" />
-    <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.44.4" PrivateAssets="none" AutomaticVersionRange="false" />
+    <PackageReference Include="Particular.Packaging" Version="4.2.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.PlatformSample.ServiceControl" Version="6.1.2" PrivateAssets="None" AutomaticVersionRange="false" />
+    <PackageReference Include="Particular.PlatformSample.ServicePulse" Version="1.44.4" PrivateAssets="None" AutomaticVersionRange="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Octopus Deploy isn't used for any additional steps like creating release notes, so this PR removes Octopus from the equation and pushes packages straight to NuGet.

After merging, the Octopus project for Particular.PlatformSample can be deleted.

Also related to the following PRs to simplify the ServiceControl and ServicePulse release procedure:

* https://github.com/Particular/Particular.PlatformSample/pull/472
* https://github.com/Particular/MonitoringDemo/pull/195