### PR TITLE
Visual test stability & future auto-release capability

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,3 +32,23 @@ jobs:
           $nextMinor = "$($latest.Major).$($latest.Minor + 1).0"
           echo "Next release should be $nextMinor"
           # gh release create $nextMinor --latest --notes "Automatically generated due to updates in ${{ steps.dependabot.outputs.dependency-names }}"
+      - name: Alternative using git diff
+        run: |
+          # Get the diff of the component csproj file between the base and head of the just-merged PR
+          $diff = $(git diff ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha src/Particular.PlatformSample/Particular.PlatformSample.csproj }})
+          # Grep search for lines that show an addition contianing ServiceControl/ServicePulse
+          $updates = $diff | grep -E '^\+\s+<PackageReference Include="Particular\.PlatformSample\.(ServiceControl|ServicePulse)"'
+          # Get number of lines
+          $lines = ($updates | Measure-Object -Line).Lines
+
+          if ($lines -eq 0) {
+            echo "Nothing to release"
+          } else {
+            echo "Need to release, in theory"
+            $tags = gh api /repos/${{ github.repository }}/tags | ConvertFrom-Json
+            $latest = [Version]($tags | Where-Object name -match '^\d+\.\d+\.\d+$' | Sort-Object -Descending {[Version]$_.name} | Select-Object name)[0].name
+            $nextMinor = "$($latest.Major).$($latest.Minor + 1).0"
+            echo "Next release should be $nextMinor"
+            # gh release create $nextMinor --latest --notes "Automatically generated due to updates in ${{ steps.dependabot.outputs.dependency-names }}"
+          }
+          

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,7 +21,7 @@ jobs:
         run: echo "$GITHUB_CONTEXT"
       - name: Get Dependabot metadata
         id: dependabot
-        if: ${{ github.actor == 'dependabot[bot]' }}
+        if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
         uses: dependabot/fetch-metadata@v2.3.0
       - name: Evaluate metadata
         if: ${{ steps.dependabot.outputs.target-branch == github.event.repository.default_branch && contains(steps.dependabot.outputs.dependency-names, 'Particular.PlatformSample.') }}

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -31,17 +31,15 @@ public class VisualTests
 
         while (TestPortsInternal.ServicePulse == 0)
         {
-            TestContext.Out.WriteLine("Waiting 1s for ServicePulse port to be available");
             await Task.Delay(1000, closePlatformTokenSource.Token);
         }
 
-        TestContext.Out.WriteLine("Waiting for ServicePulse to respond over HTTP");
         await Network.WaitForHttpOk($"http://localhost:{TestPortsInternal.ServicePulse}", cancellationToken: timeoutTokenSource.Token);
 
-        TestContext.Out.WriteLine("Initializing Chrome Driver");
         var chromeOpts = new ChromeOptions();
         chromeOpts.AddArgument("--headless=new");
-        chromeOpts.AddArgument("no-sandbox");
+        chromeOpts.AddArgument("--no-sandbox");
+        chromeOpts.AddArgument("--disable-dev-shm-usage");
         if (Environment.GetEnvironmentVariable("CI") == "true")
         {
             var runnerTemp = Environment.GetEnvironmentVariable("RUNNER_TEMP");

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -31,13 +31,15 @@ public class VisualTests
 
         while (TestPortsInternal.ServicePulse == 0)
         {
-            await Task.Delay(500, closePlatformTokenSource.Token);
+            Console.WriteLine("Waiting 1s for ServicePulse port to be avialable");
+            await Task.Delay(1000, closePlatformTokenSource.Token);
         }
 
         await Network.WaitForHttpOk($"http://localhost:{TestPortsInternal.ServicePulse}", cancellationToken: timeoutTokenSource.Token);
 
         var chromeOpts = new ChromeOptions();
         chromeOpts.AddArgument("--headless=new");
+        chromeOpts.AddArgument("no-sandbox");
         if (Environment.GetEnvironmentVariable("CI") == "true")
         {
             var runnerTemp = Environment.GetEnvironmentVariable("RUNNER_TEMP");
@@ -62,8 +64,9 @@ public class VisualTests
     [Test]
     public async Task ShouldBeConnected()
     {
+        await Task.Delay(2000);
         driver.Navigate().GoToUrl($"http://localhost:{TestPortsInternal.ServicePulse}/#/dashboard");
-        await Task.Delay(5000);
+        await Task.Delay(10_000);
 
         var connectionFailedSpans = driver.FindElements(By.CssSelector(".connection-failed"));
         Assert.That(connectionFailedSpans.Count, Is.EqualTo(0));
@@ -75,8 +78,9 @@ public class VisualTests
     [Test]
     public async Task CheckMonitoringPage()
     {
+        await Task.Delay(2000);
         driver.Navigate().GoToUrl($"http://localhost:{TestPortsInternal.ServicePulse}/#/monitoring");
-        await Task.Delay(5000);
+        await Task.Delay(10_000);
 
         var primaryButtons = driver.FindElements(By.CssSelector(".btn.btn-primary"));
         var noEndpointsButton = primaryButtons.Where(b => b.Text.Contains("how to enable endpoint monitoring")).FirstOrDefault();

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -31,12 +31,14 @@ public class VisualTests
 
         while (TestPortsInternal.ServicePulse == 0)
         {
-            Console.WriteLine("Waiting 1s for ServicePulse port to be avialable");
+            TestContext.Out.WriteLine("Waiting 1s for ServicePulse port to be available");
             await Task.Delay(1000, closePlatformTokenSource.Token);
         }
 
+        TestContext.Out.WriteLine("Waiting for ServicePulse to respond over HTTP");
         await Network.WaitForHttpOk($"http://localhost:{TestPortsInternal.ServicePulse}", cancellationToken: timeoutTokenSource.Token);
 
+        TestContext.Out.WriteLine("Initializing Chrome Driver");
         var chromeOpts = new ChromeOptions();
         chromeOpts.AddArgument("--headless=new");
         chromeOpts.AddArgument("no-sandbox");
@@ -54,6 +56,7 @@ public class VisualTests
     [OneTimeTearDown]
     public async Task TearDown()
     {
+        TestContext.Out.WriteLine("Cleaning up Chrome Driver");
         await closePlatformTokenSource.CancelAsync();
         await launcherTask;
         closePlatformTokenSource.Dispose();

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -38,6 +38,9 @@ public class VisualTests
 
         var chromeOpts = new ChromeOptions();
         chromeOpts.AddArgument("--headless=new");
+        chromeOpts.AddArgument("--disable-gpu");
+        chromeOpts.AddArgument("--ignore-certificate-errors");
+        chromeOpts.AddArgument("--disable-extensions");
         chromeOpts.AddArgument("--no-sandbox");
         chromeOpts.AddArgument("--disable-dev-shm-usage");
         if (Environment.GetEnvironmentVariable("CI") == "true")
@@ -54,7 +57,6 @@ public class VisualTests
     [OneTimeTearDown]
     public async Task TearDown()
     {
-        TestContext.Out.WriteLine("Cleaning up Chrome Driver");
         await closePlatformTokenSource.CancelAsync();
         await launcherTask;
         closePlatformTokenSource.Dispose();

--- a/src/Particular.PlatformSample.Tests/VisualTests.cs
+++ b/src/Particular.PlatformSample.Tests/VisualTests.cs
@@ -43,6 +43,12 @@ public class VisualTests
         chromeOpts.AddArgument("--disable-extensions");
         chromeOpts.AddArgument("--no-sandbox");
         chromeOpts.AddArgument("--disable-dev-shm-usage");
+        chromeOpts.AddArgument("--disk-cache-size=1");
+        chromeOpts.AddArgument("--media-cache-size=1");
+        chromeOpts.AddArgument("--incognito");
+        chromeOpts.AddArgument("--remote-debugging-port=9222");
+        chromeOpts.AddArgument("--aggressive-cache-discard");
+
         if (Environment.GetEnvironmentVariable("CI") == "true")
         {
             var runnerTemp = Environment.GetEnvironmentVariable("RUNNER_TEMP");
@@ -51,7 +57,8 @@ public class VisualTests
             chromeOpts.AddArgument($"--user-data-dir={dataDir}");
         }
 
-        driver = new ChromeDriver(chromeOpts);
+        var chromeService = ChromeDriverService.CreateDefaultService();
+        driver = new ChromeDriver(chromeService, chromeOpts, TimeSpan.FromSeconds(90));
     }
 
     [OneTimeTearDown]


### PR DESCRIPTION
* github.actor ended up being the person who merges the pull request, i.e. me, not dependabot
* Also trying another method to trigger auto-release that wouldn't depend on Dependabot
* Adding Visual Tests debug logging and (hopefully) test stability improvements in Chrome Driver based on [this question](https://stackoverflow.com/questions/22322596/selenium-error-the-http-request-to-the-remote-webdriver-timed-out-after-60-sec)