### PR TITLE
Use ParticularBot token so that pushing tag will trigger a release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,10 +5,9 @@ on:
 defaults:
   run:
     shell: pwsh
-permissions:
-  contents: write
 env:
-  GH_TOKEN: ${{ github.token }}
+  # Because actions using `github.token` cannot trigger other workflows to occur
+  GH_TOKEN: ${{ secrets.PARTICULARBOT_GITHUB_TOKEN }}
 jobs:
   auto-release:
     name: Automatic Release


### PR DESCRIPTION
As documented in [Triggering a workflow from a workflow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.