### PR TITLE
ObjectDisposedException fix and cleanup

### DIFF
--- a/src/Particular.PlatformSample/AppLauncher.cs
+++ b/src/Particular.PlatformSample/AppLauncher.cs
@@ -10,18 +10,11 @@
     using System.Threading.Tasks;
     using Raven.Embedded;
 
-    class AppLauncher : IDisposable
+    class AppLauncher(bool showPlatformToolConsoleOutput) : IDisposable
     {
-        readonly string platformPath;
-        readonly bool hideConsoleOutput;
-        readonly Stack<Action> cleanupActions;
-
-        public AppLauncher(bool showPlatformToolConsoleOutput)
-        {
-            platformPath = Path.Combine(AppContext.BaseDirectory, "platform");
-            hideConsoleOutput = !showPlatformToolConsoleOutput;
-            cleanupActions = new Stack<Action>();
-        }
+        readonly string platformPath = Path.Combine(AppContext.BaseDirectory, "platform");
+        readonly bool hideConsoleOutput = !showPlatformToolConsoleOutput;
+        readonly Stack<Action> cleanupActions = new();
 
         public Task<Uri> RavenDB(string logsPath, string dataDirectory, CancellationToken cancellationToken = default)
         {
@@ -105,7 +98,7 @@
 
         void StartProcess(string assemblyPath, Dictionary<string, string> environmentVariables = null)
         {
-            var workingDirectory = Path.GetDirectoryName(assemblyPath);
+            var workingDirectory = Path.GetDirectoryName(assemblyPath)!;
 
             var startInfo = new ProcessStartInfo("dotnet", assemblyPath)
             {

--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -39,7 +39,14 @@
             Console.CancelKeyPress += (sender, args) =>
             {
                 args.Cancel = true;
-                tokenSource.Cancel();
+                try
+                {
+                    tokenSource.Cancel();
+                }
+                catch (ObjectDisposedException)
+                {
+                    // ignore
+                }
             };
 
             var ports = Network.FindAvailablePorts(PortStartSearch, 6);

--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -29,13 +29,6 @@
         {
             using var tokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-            var wait = new ManualResetEvent(false);
-
-            tokenSource.Token.Register(() =>
-            {
-                wait.Set();
-            });
-
             Console.CancelKeyPress += (sender, args) =>
             {
                 args.Cancel = true;
@@ -117,7 +110,16 @@
 
                 Console.WriteLine();
                 Console.WriteLine("Press Ctrl+C stop Particular Service Platform tools.");
-                wait.WaitOne();
+
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, tokenSource.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (tokenSource.Token.IsCancellationRequested)
+                {
+                    // ignore
+                }
             }
 
             Console.WriteLine();


### PR DESCRIPTION
During the monitoring demo tests on MacOS I got a few of those

```chsarp
Unhandled exception. System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.Cancel()
   at Particular.PlatformLauncher.<>c__DisplayClass1_0.<Launch>b__1(Object sender, ConsoleCancelEventArgs args) in /_/src/Particular.PlatformSample/PlatformLauncher.cs:line 42
   at System.Console.HandlePosixSignal(PosixSignalContext ctx)
   at System.Runtime.InteropServices.PosixSignalRegistration.<OnPosixSignal>g__HandleSignal|10_0(Object state)
   at System.Threading.Thread.StartCallback()
```