### PR TITLE
Bring over more robust shutdown logic from ServiceControl

### DIFF
--- a/src/Particular.PlatformSample/PlatformLauncher.cs
+++ b/src/Particular.PlatformSample/PlatformLauncher.cs
@@ -75,7 +75,8 @@
             Console.WriteLine("Creating transport folder");
             var transportPath = finder.GetDirectory(".learningtransport");
 
-            using var launcher = new AppLauncher(showPlatformToolConsoleOutput);
+            var launcher = new AppLauncher(showPlatformToolConsoleOutput);
+            await using var _ = launcher.ConfigureAwait(false);
 
             Console.WriteLine("Launching RavenDB");
             var serverUri = await launcher.RavenDB(ravenLogs, ravenDB, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
During various runs of the platform samples it happened that RavenDB stuck around so I adopted the more robust shutdown behavior recently added to ServiceControl