### PR TITLE
Don't set `DEFAULT_ROUTE` env var when the default route argument is not specified

### DIFF
--- a/src/Particular.PlatformSample/AppLauncher.cs
+++ b/src/Particular.PlatformSample/AppLauncher.cs
@@ -143,8 +143,12 @@
                 { "ASPNETCORE_HTTP_PORTS", port.ToString() },
                 { "SERVICECONTROL_URL", $"http://localhost:{serviceControlPort}" },
                 { "MONITORING_URL", $"http://localhost:{monitoringPort}" },
-                { "DEFAULT_ROUTE", defaultRoute }
             };
+
+            if (defaultRoute != null)
+            {
+                environmentVariables.Add("DEFAULT_ROUTE", defaultRoute);
+            }
 
             StartProcess(Path.Combine(platformPath, "servicepulse", "ServicePulse.dll"), environmentVariables);
         }


### PR DESCRIPTION
[ServiceControl assumes that the default route should be used only when the `DEFAULT_ROUTE` is missing](https://github.com/Particular/ServicePulse/blob/master/src/ServicePulse/Settings.cs#L41). Otherwise, the provided value will be used. 

This results in PlatformSample making ServicePaulse launch `/#/` route when the default route is not specified.